### PR TITLE
component: more defensive checks to avoid null or undefined errors

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -61,8 +61,8 @@ export default class Component {
 	 */ 
 	_configureData() {
 		const DOMData = {};
-		[].forEach.call(this.el.attributes, (attr) => {
-			if (/^data-/.test(attr.name)) {
+		this.el && this.el.attributes && [].forEach.call(this.el.attributes, (attr) => {
+			if (attr && attr.name && /^data-/.test(attr.name)) {
 				var camelCaseName = attr.name.substr(5).replace(/-(.)/g, ($0, $1) => {
 					return $1.toUpperCase();
 				});


### PR DESCRIPTION
If, for some reason, `this.el.attributes` is undefined, this loop will throw an error.

This simply makes it a little more defensive.